### PR TITLE
Finding shifts between images using correlation

### DIFF
--- a/examples/coarse_alignment.py
+++ b/examples/coarse_alignment.py
@@ -1,9 +1,7 @@
 import mrcfile
-import numpy as np
 import torch
 import torch.nn.functional as F
 import einops
-from itertools import combinations
 from torch_cubic_spline_grids import CubicBSplineGrid1d
 
 from libtilt.backprojection import backproject_fourier
@@ -13,8 +11,8 @@ from libtilt.rescaling.rescale_fourier import rescale_2d
 from libtilt.shapes import circle
 from libtilt.shift.shift_image import shift_2d
 from libtilt.transformations import Ry, Rz, T
-from libtilt.correlation import correlate_2d
 from libtilt.projection import project_image_real
+from libtilt.alignment import find_image_shift
 
 IMAGE_FILE = 'data/tomo200528_100.st'
 IMAGE_PIXEL_SIZE = 1.724
@@ -64,13 +62,9 @@ coarse_shifts = torch.zeros((len(tilt_series), 2), dtype=torch.float32)
 # find coarse alignment for negative tilts
 current_shift = reference_shift.clone()
 for i in range(REFERENCE_TILT, 0, -1):
-    correlation = correlate_2d(
+    shift = find_image_shift(
         tilt_series[i] * coarse_alignment_mask,
         tilt_series[i - 1] * coarse_alignment_mask,
-        normalize=True
-    )
-    shift = center - torch.tensor(
-        np.unravel_index(correlation.argmax(), shape=tilt_dimensions)
     )
     current_shift += shift
     coarse_shifts[i - 1] = current_shift
@@ -78,13 +72,9 @@ for i in range(REFERENCE_TILT, 0, -1):
 # find coarse alignment positive tilts
 current_shift = reference_shift.clone()
 for i in range(REFERENCE_TILT, tilt_series.shape[0] - 1, 1):
-    correlation = correlate_2d(
+    shift = find_image_shift(
         tilt_series[i] * coarse_alignment_mask,
         tilt_series[i + 1] * coarse_alignment_mask,
-        normalize=True
-    )
-    shift = center - torch.tensor(
-        np.unravel_index(correlation.argmax(), shape=tilt_dimensions)
     )
     current_shift += shift
     coarse_shifts[i + 1] = current_shift

--- a/examples/coarse_alignment.py
+++ b/examples/coarse_alignment.py
@@ -80,7 +80,7 @@ for i in range(REFERENCE_TILT, tilt_series.shape[0] - 1, 1):
     coarse_shifts[i + 1] = current_shift
 
 # create aligned stack for common lines; apply the mask here to prevent recalculation
-coarse_aligned_masked = shift_2d(tilt_series, shifts=-coarse_shifts) * coarse_alignment_mask
+coarse_aligned_masked = shift_2d(tilt_series, shifts=coarse_shifts) * coarse_alignment_mask
 # generate a weighting for the common line ROI by projecting the mask
 mask_weights = project_image_real(coarse_alignment_mask, torch.eye(2).reshape(1, 2, 2))
 mask_weights /= mask_weights.max()  # normalise to 0 and 1
@@ -130,7 +130,7 @@ tilt_axis_prediction = tilt_axis_grid(interpolation_points).clone().detach()
 print('final tilt axis angle:', torch.unique(tilt_axis_prediction))
 
 # create the aligned stack
-coarse_aligned = shift_2d(tilt_series, shifts=-coarse_shifts)
+coarse_aligned = shift_2d(tilt_series, shifts=coarse_shifts)
 
 tomogram_center = dft_center(tomogram_dimensions, rfft=False, fftshifted=True)
 tilt_image_center = dft_center(tilt_dimensions, rfft=False, fftshifted=True)

--- a/src/libtilt/alignment/__init__.py
+++ b/src/libtilt/alignment/__init__.py
@@ -1,0 +1,1 @@
+from .find_shift import find_image_shift

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -23,7 +23,7 @@ def find_image_shift(
     image_a: torch.Tensor
         `(h, w)` image.
     image_b: torch.Tensor
-        `(y, x)` image with the same shape as image_a
+        `(h, w)` image with the same shape as image_a
     upsampling_factor: float
         How many times the correlation image is upsampled with bicubic
         interpolation to find an interpolated shift. The value needs to be larger or

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -37,10 +37,12 @@ def find_image_shift(
     if upsampling_factor < 1:
         raise ValueError('Upsampling factor for finding a shift between two images '
                          'cannot be smaller than 1.')
-    image_shape = torch.tensor(image_a.shape, device=image_a.device)
     center = dft_center(
         image_a.shape, rfft=False, fftshifted=True, device=image_a.device
     )
+    image_shape = torch.tensor(image_a.shape, device=image_a.device)
+
+    # calculate initial shift with integer precision
     correlation = correlate_2d(
         image_a,
         image_b,
@@ -51,6 +53,8 @@ def find_image_shift(
         device=image_a.device
     )
     shift = center - maximum_idx
+
+    # attempt interpolating the shift for higher precision
     if upsampling_factor == 1:
         return shift
     elif torch.any(maximum_idx < 2) or torch.any(image_shape - maximum_idx < 3):

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -21,7 +21,7 @@ def find_image_shift(
     Parameters
     ----------
     image_a: torch.Tensor
-        `(y, x)` image.
+        `(h, w)` image.
     image_b: torch.Tensor
         `(y, x)` image with the same shape as image_a
     upsampling_factor: float

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -1,0 +1,70 @@
+import torch
+import numpy as np
+import torch.nn.functional as F
+import einops
+
+from libtilt.correlation import correlate_2d
+from libtilt.fft_utils import dft_center
+
+
+def find_image_shift(
+        image_a: torch.Tensor,
+        image_b: torch.Tensor,
+        upsampling_factor: float = 10,
+) -> torch.Tensor:
+    """
+
+    Parameters
+    ----------
+    image_a: torch.Tensor
+        `(y, x)` image.
+    image_b: torch.Tensor
+        `(y, x)` image with the same shape as image_a
+    upsampling_factor: float
+        how many times the correlation image is upsampled with bicubic
+        interpolation to find an interpolated shift
+
+    Returns
+    -------
+    projections: torch.Tensor
+        `(..., d, d)` array of projection images.
+    """
+    image_shape = image_a.shape
+    center = dft_center(
+        image_shape, rfft=False, fftshifted=True, device=image_a.device
+    )
+    correlation = correlate_2d(
+        image_a,
+        image_b,
+        normalize=True
+    )
+    maximum_idx = torch.tensor(  # explicitly put tensor on CPU in case input is on GPU
+        np.unravel_index(correlation.argmax().cpu(), shape=image_shape),
+        device=image_a.device
+    )
+    shift = center - maximum_idx
+    if torch.any(maximum_idx < 2) or torch.any(image_shape - maximum_idx < 3):
+        # if the maximum is too close to the border, it cannot be upsampled
+        return shift
+    else:  # find interpolated shift by upsampling the correlation image
+        peak_region_y = slice(maximum_idx[0] - 2, maximum_idx[0] + 3)
+        peak_region_x = slice(maximum_idx[1] - 2, maximum_idx[1] + 3)
+        upsampled = F.interpolate(
+            einops.rearrange(
+                correlation[peak_region_y, peak_region_x],
+                'h w -> 1 1 h w'
+            ),
+            scale_factor=upsampling_factor,
+            mode='bicubic',
+            align_corners=True
+        )
+        upsampled = einops.rearrange(upsampled, '1 1 h w -> h w')
+        upsampled_center = dft_center(
+            upsampled.shape, rfft=False, fftshifted=True, device=image_a.device
+        )
+        upsampled_shift = upsampled_center - torch.tensor(
+            np.unravel_index(upsampled.argmax().cpu(), shape=upsampled.shape),
+            device=image_a.device
+        )
+        full_shift = shift + upsampled_shift / upsampling_factor
+        return full_shift

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -37,9 +37,9 @@ def find_image_shift(
     if upsampling_factor < 1:
         raise ValueError('Upsampling factor for finding a shift between two images '
                          'cannot be smaller than 1.')
-    image_shape = image_a.shape
+    image_shape = torch.tensor(image_a.shape, device=image_a.device)
     center = dft_center(
-        image_shape, rfft=False, fftshifted=True, device=image_a.device
+        image_a.shape, rfft=False, fftshifted=True, device=image_a.device
     )
     correlation = correlate_2d(
         image_a,
@@ -47,7 +47,7 @@ def find_image_shift(
         normalize=True
     )
     maximum_idx = torch.tensor(  # explicitly put tensor on CPU in case input is on GPU
-        np.unravel_index(correlation.argmax().cpu(), shape=image_shape),
+        np.unravel_index(correlation.argmax().cpu(), shape=image_a.shape),
         device=image_a.device
     )
     shift = center - maximum_idx

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -12,11 +12,9 @@ def find_image_shift(
         image_b: torch.Tensor,
         upsampling_factor: float = 10,
 ) -> torch.Tensor:
-    """Find the shift between two images. The shift specifies how far image_b is
-    shifted relative to image_a. Applying this shift to image_a will align it with
-    image_b. Applying the inverse shift to b, will align it with image_a. The
-    region around the maximum in the correlation image is by default upsampled with
-    bicubic interpolation to find a more precise shift.
+    """Find the shift between image a and b. Applying the shift to b aligns it with
+    image a. The region around the maximum in the correlation image is by default
+    upsampled with bicubic interpolation to find a more precise shift.
 
     Parameters
     ----------

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -52,7 +52,7 @@ def find_image_shift(
         np.unravel_index(correlation.argmax().cpu(), shape=image_a.shape),
         device=image_a.device
     )
-    shift = center - maximum_idx
+    shift = maximum_idx - center
 
     # attempt interpolating the shift for higher precision
     if upsampling_factor == 1:
@@ -77,9 +77,9 @@ def find_image_shift(
         upsampled_center = dft_center(
             upsampled.shape, rfft=False, fftshifted=True, device=image_a.device
         )
-        upsampled_shift = upsampled_center - torch.tensor(
+        upsampled_shift = torch.tensor(
             np.unravel_index(upsampled.argmax().cpu(), shape=upsampled.shape),
             device=image_a.device
-        )
+        ) - upsampled_center
         full_shift = shift + upsampled_shift / upsampling_factor
         return full_shift

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -12,7 +12,11 @@ def find_image_shift(
         image_b: torch.Tensor,
         upsampling_factor: float = 10,
 ) -> torch.Tensor:
-    """
+    """Find the shift between two images. The shift specifies how far image_b is
+    shifted relative to image_a. Applying this shift to image_a will align it with
+    image_b. Applying the inverse shift to b, will align it with image_a. The
+    region around the maximum in the correlation image is by default upsampled with
+    bicubic interpolation to find a more precise shift.
 
     Parameters
     ----------
@@ -21,14 +25,18 @@ def find_image_shift(
     image_b: torch.Tensor
         `(y, x)` image with the same shape as image_a
     upsampling_factor: float
-        how many times the correlation image is upsampled with bicubic
-        interpolation to find an interpolated shift
+        How many times the correlation image is upsampled with bicubic
+        interpolation to find an interpolated shift. The value needs to be larger or
+        equal to 1.
 
     Returns
     -------
-    projections: torch.Tensor
-        `(..., d, d)` array of projection images.
+    shift: torch.Tensor
+        `(2, )` shift in y and x.
     """
+    if upsampling_factor < 1:
+        raise ValueError('Upsampling factor for finding a shift between two images '
+                         'cannot be smaller than 1.')
     image_shape = image_a.shape
     center = dft_center(
         image_shape, rfft=False, fftshifted=True, device=image_a.device
@@ -43,10 +51,13 @@ def find_image_shift(
         device=image_a.device
     )
     shift = center - maximum_idx
-    if torch.any(maximum_idx < 2) or torch.any(image_shape - maximum_idx < 3):
+    if upsampling_factor == 1:
+        return shift
+    elif torch.any(maximum_idx < 2) or torch.any(image_shape - maximum_idx < 3):
         # if the maximum is too close to the border, it cannot be upsampled
         return shift
-    else:  # find interpolated shift by upsampling the correlation image
+    else:
+        # find interpolated shift by upsampling the correlation image
         peak_region_y = slice(maximum_idx[0] - 2, maximum_idx[0] + 3)
         peak_region_x = slice(maximum_idx[1] - 2, maximum_idx[1] + 3)
         upsampled = F.interpolate(

--- a/src/libtilt/alignment/tests/test_find_shift.py
+++ b/src/libtilt/alignment/tests/test_find_shift.py
@@ -15,7 +15,7 @@ def test_find_image_shift():
         find_image_shift(a, b, upsampling_factor=0.5)
 
     shift = find_image_shift(a, b, upsampling_factor=5)
-    assert torch.all(shift == 1), ("Interpolating a shift too close to a border is "
+    assert torch.all(shift == -1), ("Interpolating a shift too close to a border is "
                                    "not possible, so an integer shift should be "
                                    "returned.")
 
@@ -25,10 +25,10 @@ def test_find_image_shift():
     b[4, 4] = .7
     b[4, 5] = .3
     shift = find_image_shift(a, b, upsampling_factor=1)
-    assert torch.all(shift == 1), ("Finding shift with upsampling_factor of 1 should "
+    assert torch.all(shift == -1), ("Finding shift with upsampling_factor of 1 should "
                                    "return an integer shift (i.e. no interpolation.")
 
     shift = find_image_shift(a, b)
-    assert shift[0] == 1.1, "y shift should be interpolated to specific value."
-    assert shift[1] == 1.2, "x shift should be interpolated to specific value."
+    assert shift[0] == -1.1, "y shift should be interpolated to specific value."
+    assert shift[1] == -1.2, "x shift should be interpolated to specific value."
 

--- a/src/libtilt/alignment/tests/test_find_shift.py
+++ b/src/libtilt/alignment/tests/test_find_shift.py
@@ -1,0 +1,34 @@
+import torch
+import pytest
+
+from libtilt.alignment import find_image_shift
+
+
+def test_find_image_shift():
+    a = torch.zeros((4, 4))
+    a[1, 1] = 1
+    b = torch.zeros((4, 4))
+    b[2, 2] = .7
+    b[2, 3] = .3
+
+    with pytest.raises(ValueError, match=r'Upsampling factor .*'):
+        find_image_shift(a, b, upsampling_factor=0.5)
+
+    shift = find_image_shift(a, b, upsampling_factor=5)
+    assert torch.all(shift == 1), ("Interpolating a shift too close to a border is "
+                                   "not possible, so an integer shift should be "
+                                   "returned.")
+
+    a = torch.zeros((8, 8))
+    a[3, 3] = 1
+    b = torch.zeros((8, 8))
+    b[4, 4] = .7
+    b[4, 5] = .3
+    shift = find_image_shift(a, b, upsampling_factor=1)
+    assert torch.all(shift == 1), ("Finding shift with upsampling_factor of 1 should "
+                                   "return an integer shift (i.e. no interpolation.")
+
+    shift = find_image_shift(a, b)
+    assert shift[0] == 1.1, "y shift should be interpolated to specific value."
+    assert shift[1] == 1.2, "x shift should be interpolated to specific value."
+


### PR DESCRIPTION
Some simple functionality for finding a shift between two images based around correlate_2d. The code uses torch interpolation to upsample the correlation image and find a more precise maximum with bicubic interpolation. 

The function now outputs the shift of image b relative to image a. This means that by applying the inverse of the shift to image b, it is aligned with image a. To me that makes sense but let me know what you think.