### PR TITLE
fix padding in rescaling to use reflect correctly

### DIFF
--- a/src/libtilt/fft_utils.py
+++ b/src/libtilt/fft_utils.py
@@ -411,9 +411,14 @@ def _pad_to_best_fft_shape_2d(
     # pad to best fft size
     h, w = image.shape[-2:]
     ph, pw = fft_size_h - h, fft_size_w - w
-    too_much_padding = ph > h or pw > w
+    too_much_padding = ph < h or pw < w
     if too_much_padding:
-        image = F.pad(image, pad=(0, pw, 0, ph), mode='constant', value=image.mean())
+        image_means = einops.reduce(
+            image, 'tilt h w -> tilt 1 1', reduction='mean'
+        )
+        image -= image_means
+        image = F.pad(image, pad=(0, pw, 0, ph), mode='constant', value=0)
+        image += image_means
     else:
         image = F.pad(image, pad=(0, pw, 0, ph), mode='reflect')
     [image] = einops.unpack(image, pattern='* h w', packed_shapes=ps)

--- a/src/libtilt/fft_utils.py
+++ b/src/libtilt/fft_utils.py
@@ -411,7 +411,7 @@ def _pad_to_best_fft_shape_2d(
     # pad to best fft size
     h, w = image.shape[-2:]
     ph, pw = fft_size_h - h, fft_size_w - w
-    too_much_padding = ph < h or pw < w
+    too_much_padding = ph > h or pw > w
     if too_much_padding:
         image_means = einops.reduce(
             image, 'tilt h w -> tilt 1 1', reduction='mean'

--- a/src/libtilt/fft_utils.py
+++ b/src/libtilt/fft_utils.py
@@ -412,8 +412,10 @@ def _pad_to_best_fft_shape_2d(
     h, w = image.shape[-2:]
     ph, pw = fft_size_h - h, fft_size_w - w
     too_much_padding = ph > h or pw > w
-    padding_mode = 'reflect' if too_much_padding is False else 'constant'
-    image = F.pad(image, pad=(0, pw, 0, ph), mode=padding_mode)
+    if too_much_padding:
+        image = F.pad(image, pad=(0, pw, 0, ph), mode='constant', value=image.mean())
+    else:
+        image = F.pad(image, pad=(0, pw, 0, ph), mode='reflect')
     [image] = einops.unpack(image, pattern='* h w', packed_shapes=ps)
     return image
 

--- a/src/libtilt/fft_utils.py
+++ b/src/libtilt/fft_utils.py
@@ -414,7 +414,7 @@ def _pad_to_best_fft_shape_2d(
     too_much_padding = ph > h or pw > w
     if too_much_padding:
         image_means = einops.reduce(
-            image, 'tilt h w -> tilt 1 1', reduction='mean'
+            image, '... h w -> ... 1 1', reduction='mean'
         )
         image -= image_means
         image = F.pad(image, pad=(0, pw, 0, ph), mode='constant', value=0)


### PR DESCRIPTION
The imaged I attached in #63 showed a strong edge artifact, which I first though came from shifting. Turns out it originates from rescaling. Apparently the padding with zeros during rescaling created lines in my tilt-series, as visible in the top left corner of this image:

![rescale_edges_from_zero_padding](https://github.com/teamtomo/libtilt/assets/58044494/514dab4a-5cd7-458d-87fa-0df7f355be73)

I made a small fix in _pad_to_best_fft_shape_2d as it was not correctly switching to 'reflect' mode. Also a suggested change to pad images with the image mean as the constant value for too much padding to still somewhat reduce edges. Now rescaling looks like this:

![rescale_edges_with_reflection](https://github.com/teamtomo/libtilt/assets/58044494/b664cd70-9f8c-4540-81a0-a1da24788277)

And it edges after shifting are indeed reduced:

![reduced_edge_artifact_after_shift](https://github.com/teamtomo/libtilt/assets/58044494/766dcbe6-238b-47a3-92de-d38be38a4800)


