### PR TITLE
Torch unravel index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = ["version"]
 dependencies = [
     "torch",
     "numpy",
+    "scipy",
     "einops",
     "torch-cubic-spline-grids",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "torch",
+    "torch>=2.2",
     "numpy",
     "scipy",
     "einops",

--- a/src/libtilt/alignment/find_shift.py
+++ b/src/libtilt/alignment/find_shift.py
@@ -47,7 +47,7 @@ def find_image_shift(
         normalize=True
     )
     maximum_idx = torch.tensor(  # explicitly put tensor on CPU in case input is on GPU
-        np.unravel_index(correlation.argmax().cpu(), shape=image_a.shape),
+        torch.unravel_index(correlation.argmax().cpu(), shape=image_a.shape),
         device=image_a.device
     )
     shift = maximum_idx - center
@@ -76,7 +76,7 @@ def find_image_shift(
             upsampled.shape, rfft=False, fftshifted=True, device=image_a.device
         )
         upsampled_shift = torch.tensor(
-            np.unravel_index(upsampled.argmax().cpu(), shape=upsampled.shape),
+            torch.unravel_index(upsampled.argmax().cpu(), shape=upsampled.shape),
             device=image_a.device
         ) - upsampled_center
         full_shift = shift + upsampled_shift / upsampling_factor

--- a/src/libtilt/correlation/tests/test_correlate.py
+++ b/src/libtilt/correlation/tests/test_correlate.py
@@ -11,7 +11,7 @@ def test_correlate_2d():
     b = torch.zeros((10, 10))
     b[6, 6] = 1
     cross_correlation = correlate_2d(a, b, normalize=True)
-    peak_position = np.unravel_index(
+    peak_position = torch.unravel_index(
         indices=torch.argmax(cross_correlation), shape=cross_correlation.shape
     )
     shift = torch.as_tensor(peak_position) - torch.tensor([5, 5])


### PR DESCRIPTION
Ran latest install to work on device agnostic tests, and had some issues with the tests. 

Latest install results in numpy=2 which gave some issues with implicit array copying:

```
    def test_correlate_2d():
        a = torch.zeros((10, 10))
        a[5, 5] = 1
        b = torch.zeros((10, 10))
        b[6, 6] = 1
        cross_correlation = correlate_2d(a, b, normalize=True)
>       peak_position = np.unravel_index(
            indices=torch.argmax(cross_correlation), shape=cross_correlation.shape
        )
E       DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.
```

I noticed from torch 2.2 onwards they have their own unravel index, so: I updated the dependency to at least torch 2.2 and switched code to use the torch version.

Also noticed scipy was not listed as a dependency and is used in the code, so I added it to the deps.